### PR TITLE
feature : total quantity of goods in cart / F expression, transaction

### DIFF
--- a/app/carts/models.py
+++ b/app/carts/models.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.core.validators import MinValueValidator, MaxValueValidator
-from django.db import models
-from django.db.models import CASCADE
+from django.db import models, transaction
+from django.db.models import CASCADE, F
 from goods.models import Goods
 
 User = get_user_model()
@@ -12,6 +12,7 @@ class Cart(models.Model):
         User,
         on_delete=models.CASCADE,
     )
+    quantity_of_goods = models.IntegerField('총 상품 수량', default=0, null=True)
 
     @property
     def total_pay(self):
@@ -28,7 +29,7 @@ class CartItem(models.Model):
     quantity = models.IntegerField(default=1,
                                    validators=[MinValueValidator(1), MaxValueValidator(50)])
     cart = models.ForeignKey(Cart, on_delete=CASCADE, related_name='item', null=True)
-    goods = models.ForeignKey(Goods, on_delete=CASCADE, related_name='item',)
+    goods = models.ForeignKey(Goods, on_delete=CASCADE, related_name='item', )
     order = models.ForeignKey('order.Order',
                               on_delete=models.SET_NULL,
                               null=True,
@@ -45,3 +46,9 @@ class CartItem(models.Model):
             return self.sub_total()
         except AttributeError:
             return self.sub_total()
+
+    @transaction.atomic
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self.cart.quantity_of_goods = F('quantity_of_goods') + 1
+        self.cart.save()

--- a/app/carts/serializers.py
+++ b/app/carts/serializers.py
@@ -48,7 +48,7 @@ class CartSerializer(ModelSerializer):
 
     class Meta:
         model = Cart
-        fields = ('id', 'item', 'total_pay')
+        fields = ('id', 'quantity_of_goods', 'item', 'total_pay')
 
     def get_total_pay(self, obj):
         return obj.total_pay

--- a/app/event/serializers.py
+++ b/app/event/serializers.py
@@ -2,7 +2,7 @@ from action_serializer import ModelActionSerializer
 from rest_framework.serializers import ModelSerializer
 
 from .models import Event, MainEvent, MainEventType, GoodsEventType
-from goods.serializers import GoodsSerializers, GoodsSaleSerializers
+from goods.serializers import GoodsSaleSerializers
 
 
 class EventSerializers(ModelActionSerializer):

--- a/develop_log.md
+++ b/develop_log.md
@@ -143,3 +143,18 @@ export -> shell 변수들은 export 명령어와 사용이 된다면 환경 변�
 
 ## django admin page custom
 [링크](https://docs.djangoproject.com/en/3.1/ref/contrib/admin/#overriding-admin-templates)
+
+## django transaction
+#### django에서 트랜잭션을 구현하는 3가지 방법
+1. 데코레이터를 이용한 Transaction : 하나의 함수에 적용
+2. with 명령어를 이용한 트랜잭션 : 중간 부분에 적용 
+3. savepoint를 직접 지정 
+
+
+기본적으로 django는 transaction을 지원하지만, ATOMIC_REQUESTS가 False 이므로, ORM 쿼리 단위로 transaction이 관리된다. (create, delete, update, get_or_create …)
+
+그래서 어떤 특정 코드 뭉치에 DB transaction을 지원하려면, transaction.atomic과 같은 구문이 필요하다.
+
+이 때 주의할 점은 with transaction.atomic 블록 안에서 try-except를 하지말라는 것이다. (django 문서에도 언급되어 있다.)
+
+transaction.atomic() 내부에서는 try-except 를 사용하지말자. 써야만 한다면 try 블록이 transaction.atomic() 블록을 감싸도록 사용하자.


### PR DESCRIPTION
#85 장바구니에 담긴 상품의 수량을 구하는 데에 있어서
1. 현재 구현한 역 정규화로 모델에 필드 값을 추가하여 관리를 하는 것이 나은지
2. 메서드로 구현하여 cart.item_set.all().count() 을 통하여 카트를 가리키고 있는 인스턴스들의 총합을 가져온 뒤, 캐싱을 하는 방법


둘 중 어떠한 것이 성능적으로 나은 것인지 궁금합니다!
